### PR TITLE
Upgrade Baseline Jenkins Version to 2.346.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.399</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>4.40</version>
+    <relativePath/>
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -11,18 +12,21 @@
   <version>1.2-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
-  <!-- get every artifact through maven.glassfish.org, which proxies all the artifacts that we need -->
+  <properties>
+    <jenkins.version>2.303.3</jenkins.version>
+  </properties>
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,6 @@
   <artifactId>built-on-column</artifactId>
   <version>1.2-SNAPSHOT</version>
 
-  <properties>
-    <jenkins.version>2.346.3</jenkins.version>
-  </properties>
-
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
@@ -31,8 +27,7 @@
   <packaging>hpi</packaging>
   
   <properties>
-    <jenkins.version>2.249.3</jenkins.version>
-    <java.level>8</java.level>
+    <jenkins.version>2.346.3</jenkins.version>
   </properties>
   <scm>
     <connection>scm:git:ssh://github.com/jenkinsci/.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </pluginRepository>
   </pluginRepositories>
   <packaging>hpi</packaging>
-  
+
   <properties>
     <jenkins.version>2.346.3</jenkins.version>
   </properties>
@@ -43,4 +43,4 @@
       <email>voorth@xs4all.nl</email>
     </developer>
   </developers>
-</project>  
+</project>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,6 +1,7 @@
 <!--
   This view is used to render the installed plugins page.
 -->
+<?jelly escape-by-default="true"?>
 <div>
   Shows the actual node that a job was built on
 </div>

--- a/src/main/resources/org/jenkins/plugins/builton/BuiltOnColumn/column.jelly
+++ b/src/main/resources/org/jenkins/plugins/builton/BuiltOnColumn/column.jelly
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
-
+<?jelly escape-by-default="true"?>
 <j:jelly xmlns:j="jelly:core">
   <td><a href="/${job.lastBuild.builtOn.searchUrl}" class="model-link">${job.lastBuild.builtOn.displayName}</a></td>
 </j:jelly>


### PR DESCRIPTION
Hi,

These changes upgrade the Jenkins baseline version according to [current recommendations](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/). This is mainly to avoid implicit dependencies being installed.

- Upgrade parent pom to 4.40
- Upgrade Jenkins core to 2.303.3 to avoid implicit dependencies
- Add Jelly escapes - required by new tooling

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
