### PR TITLE
[JENKINS-46773] Fix link from built on column to agent page

### DIFF
--- a/src/main/resources/org/jenkins/plugins/builton/BuiltOnColumn/column.jelly
+++ b/src/main/resources/org/jenkins/plugins/builton/BuiltOnColumn/column.jelly
@@ -23,5 +23,5 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-  <td><a href="/${job.lastBuild.builtOn.searchUrl}" class="model-link">${job.lastBuild.builtOn.displayName}</a></td>
+  <td><a href="${job.lastBuild.builtOn.searchUrl}" class="model-link">${job.lastBuild.builtOn.displayName}</a></td>
 </j:jelly>

--- a/src/main/resources/org/jenkins/plugins/builton/BuiltOnColumn/column.jelly
+++ b/src/main/resources/org/jenkins/plugins/builton/BuiltOnColumn/column.jelly
@@ -23,5 +23,5 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-  <td><a href="${job.lastBuild.builtOn.searchUrl}" class="model-link">${job.lastBuild.builtOn.displayName}</a></td>
+  <td><a href="${rootURL}/${job.lastBuild.builtOn.searchUrl}" class="model-link">${job.lastBuild.builtOn.displayName}</a></td>
 </j:jelly>


### PR DESCRIPTION
## [JENKINS-46773](https://issues.jenkins.io/browse/JENKINS-46773) Fix link from built on column to agent page

The real node is `https://<hostname>/<project>/computer/<node>` but this plugin reports the node is `https://<hostname>/computer/<node>`
