### PR TITLE
Add markewaite as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* markewaite
+* @markewaite

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* markewaite


### PR DESCRIPTION
## Add markewaite as a code owner

Improve plugin health score

### Testing done

Confirmed that the more typical assignment of a group does not work.  I assume that is because there is no group @jenkinsci/built-on-column-developers defined on GitHub.


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
