### PR TITLE
Require Jenkins 2.479 and Jakarta EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.6</version>
     <relativePath />
   </parent>
 
@@ -14,13 +14,6 @@
   <packaging>hpi</packaging>
 
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-  <developers>
-    <developer>
-      <id>voorth</id>
-      <name>Henk van Voorthuijsen</name>
-      <email>voorth@xs4all.nl</email>
-    </developer>
-  </developers>
   <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
@@ -31,8 +24,8 @@
   <properties>
     <revision>1.5</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>


### PR DESCRIPTION
## Require Jenkins 2.479 and Jakarta EE 9

Jenkins 2.479.1 uses Spring Security 6, Jakarta EE 9, and Eclipse Jetty 12.  It provides a compatibility layer for plugins that use Spring Security 5, Java EE 8, and Eclipse Jetty 10, but we want to eventually remove most of the compatibility layer.  Plugins need to upgrade to require Jenkins 2.479.1 in order to stop using the compatibility layer.

Also removes the unused and outdated developer section from the pom.

### Testing done

Confirmed that there are no dependent plugins.  Verified that automated tests continue to pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
